### PR TITLE
implement Fob.PageBreak.compare/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 - 2021-03-04
+
+### Added
+
+- Added `Fob.between_bounds/3` for querying any number of records between two
+  page-breaks
+    - kind-of a book-ends concept rather than page-breaks :thinking:
+- Added `Fob.PageBreak.compare/2` and `Fob.PageBreak.compare/3` for comparing
+  lists of page breaks
+
 ## 0.1.0 - 2021-03-03
 
 ### Added

--- a/lib/fob/page_break.ex
+++ b/lib/fob/page_break.ex
@@ -6,6 +6,12 @@ defmodule Fob.PageBreak do
   # a data structure for describing where in a dataset we have drawn a page
   # line
 
+  @ascending ~w[asc asc_nulls_first asc_nulls_last]a
+
+  # N.B.
+  # :asc == :asc_nulls_last
+  # :desc == :desc_nulls_first
+
   defstruct ~w[column value table direction]a
 
   def add_query_info(nil, _), do: nil
@@ -22,4 +28,52 @@ defmodule Fob.PageBreak do
 
     %__MODULE__{page_break | table: order.table, direction: order.direction}
   end
+
+  @doc since: "0.2.0"
+  def compare(a, b, query) when is_list(a) and is_list(b) do
+    compare(add_query_info(a, query), add_query_info(b, query))
+  end
+
+  def compare(a, b)
+
+  def compare(a, b) when is_list(a) and is_list(b) and length(a) == length(b) do
+    Enum.zip(a, b)
+    |> Enum.map(fn {a, b} -> compare(a, b) end)
+    |> Enum.find(:eq, fn comparison -> comparison != :eq end)
+  end
+
+  def compare(%__MODULE__{value: a, direction: direction}, %__MODULE__{
+        value: b,
+        direction: direction
+      })
+      when is_atom(direction) and direction != nil do
+    _compare(a, b, direction)
+  end
+
+  defp _compare(a, b, direction)
+
+  defp _compare(value, value, _direction), do: :eq
+
+  defp _compare(a, b, direction) when a != nil and b != nil do
+    comparator = if direction in @ascending, do: &>/2, else: &</2
+
+    if comparator.(a, b), do: :gt, else: :lt
+  end
+
+  # nil is either infinity or -infinity depending on the direction
+  defp _compare(nil, _b, direction)
+       when direction in ~w[asc_nulls_first desc desc_nulls_first]a,
+       do: :lt
+
+  defp _compare(nil, _b, direction)
+       when direction in ~w[asc asc_nulls_last desc_nulls_last]a,
+       do: :gt
+
+  defp _compare(_a, nil, direction)
+       when direction in ~w[asc_nulls_first desc desc_nulls_first]a,
+       do: :gt
+
+  defp _compare(_a, nil, direction)
+       when direction in ~w[asc asc_nulls_last desc_nulls_last]a,
+       do: :lt
 end

--- a/test/fob/page_break_comparison_test.exs
+++ b/test/fob/page_break_comparison_test.exs
@@ -1,0 +1,46 @@
+defmodule Fob.PageBreakComparisonTest do
+  use Fob.RepoCase
+
+  @moduledoc """
+  Tests that the Fob.PageBreak.compare/2 function works as expected and respects
+  nils
+  """
+  @moduledoc since: "0.2.0"
+
+  alias Ecto.Multi
+  alias Fob.PageBreak
+
+  setup do
+    [schema: TieBreakerSchema, repo: Fob.Repo]
+  end
+
+  setup c do
+    Multi.new()
+    |> Multi.insert_all(:seeds, c.schema, c.schema.seed())
+    |> c.repo.transaction()
+
+    :ok
+  end
+
+  test "compare/3 says that the start of the dataset comes before the end", c do
+    schema = c.schema
+    query = from t in schema, order_by: [asc_nulls_last: :date, asc: :id]
+    all_records = c.repo.all(query)
+
+    for n <- 1..(length(all_records) - 1) do
+      prior_record = Fob.page_breaks(query, all_records |> Enum.at(n - 1))
+      record = Fob.page_breaks(query, all_records |> Enum.at(n))
+
+      assert PageBreak.compare(prior_record, record, query) == :lt
+    end
+
+    all_records = Enum.reverse(all_records)
+
+    for n <- 1..(length(all_records) - 1) do
+      prior_record = Fob.page_breaks(query, all_records |> Enum.at(n - 1))
+      record = Fob.page_breaks(query, all_records |> Enum.at(n))
+
+      assert PageBreak.compare(prior_record, record, query) == :gt
+    end
+  end
+end


### PR DESCRIPTION
closes #3

why are we comparing page breaks?

say that you record the bookends of where you are in a dataset with a `start` page break and a `stop` page break. (n.b. in this context a "page break" is a list of PageBreak structs, one for each criteria by which the query is ordered with `Ecto.Query.order_by/3`.). n.b. that `length(start)` always `== length(stop)` because they're from the same query!

we can think of the records within `start..stop` as an `n` dimensional space where `n = length(start) = length(stop)`; i.e. one dimension for each ordering criteria. so we can say that the values in the page braeks of `start` and `stop` (`(%PageBreak{}).value`) are n-element tuples that describe a _space_ of possible values

more concretely, say we have a query

```elixir
#Ecto.Query<from t0 in TieBreakerSchema,
 order_by: [asc_nulls_last: t0.date, asc: t0.id]>
```

we might have `start` and `stop` page-breaks like

```elixir
start = [
  %PageBreak{column: :date, value: ~D[2020-02-15], direction: :asc_nulls_last, ...},
  %PageBreak{column: :id, value: 0, direction: :asc, ...}
]
stop = [
  %PageBreak{column: :date, value: nil, direction: :asc_nulls_last, ...},
  %PageBreak{column: :id, value: 19, direction: :asc, ...}
]
```

So we could say that the space we're covering would be from these 2-dimensional tuples:

```elixir
{~D[2020-02-15], 0}..{nil, 19}
```

If we get a real-time update where we insert a new record, it could be within our `start` and `stop` or it could be outside. We need to _expand_ the space our page-breaks occupy to correctly query after an insertion real-time-update. To know whether or not we're expanding or contracting, we need to `compare/2`!

---

So how can we compare these n-dimensional tuples? Clearly in this example we know that

```elixir
{~D[2020-02-15], 0} < {nil, 19}
```

For this query because it's a contrived example and I've already told you that `start` is the start of the dataset and `stop` is the end.

But generally, we

1. consider the first element in tuple `a` (`a1`) vs the first element in tuple `b` (`b1`)
2. if they are inequal, we simply say that the whole comparison is whatever the result of that first element comparison is: `compare(a, b) == compare(a1, b1)`
3. if they are equal, we move to the next element in ecah tuple: `compare(a2, b2)`
4. if we reach the end of the tuples, the page-breaks are completely equal

And this `compare/2` subroutine on the elements of the tuples uses basic comparison: `>` or `<` taking the `Ecto.Query.order_by/3` direction into account.

---

Well what about nils???? Depending on the direction, nil may be either `-infinity` or `infinity` (in fact, we use `fragment("'-infinity'")` and `fragment("'infinity'")` postgres built-ins to do the comparisons in the database!). There's a segment of function clauses just for pattern matching those cases.