### PR TITLE
track tables when determining query ordering columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.1 - 2022-02-04
+
+### Fixed
+
+- Fixed a case where `Fob.page_breaks/2` would miscalculate the page breaks
+  when a query was ordered by a column which was also part of a `select`
+  that belonged to a joined table.
+
 ## 0.5.0 - 2021-12-03
 
 ### Changed

--- a/lib/fob.ex
+++ b/lib/fob.ex
@@ -230,10 +230,10 @@ defmodule Fob do
 
     query
     |> Ordering.columns()
-    |> Enum.map(fn column ->
-      key = Map.get(selection_mapping, column, column)
+    |> Enum.map(fn {_table, name} = column ->
+      key = Map.get(selection_mapping, column, name)
 
-      %PageBreak{column: column, value: get_in(record, [Access.key(key)])}
+      %PageBreak{column: name, value: get_in(record, [Access.key(key)])}
     end)
   end
 
@@ -260,10 +260,7 @@ defmodule Fob do
 
   defp reverse(page_breaks) do
     Enum.map(page_breaks, fn page_break ->
-      %PageBreak{
-        page_break
-        | direction: Ordering.opposite(page_break.direction)
-      }
+      update_in(page_break.direction, &Ordering.opposite/1)
     end)
   end
 end

--- a/lib/fob/page_break.ex
+++ b/lib/fob/page_break.ex
@@ -97,8 +97,8 @@ defmodule Fob.PageBreak do
   those to the held `start` and `stop` page-break values.
 
   This function performs that comparison and returns a tuple of the new
-  `start` and `stop`, where `proposed` could either replace the `start` or
-  `stop`.
+  `start` and `stop`, where `proposed` could possibly replace the `start` or
+  `stop` (or neither).
   """
   @doc since: "0.3.0"
   @spec expand_space(


### PR DESCRIPTION
This manifested itself as an interesting bug where fob would miscalculate the page breaks for a query that joined a column that exists on the top-level table, and was ordered by that column on the top-level table. Fob would think that the joined table's column would be the appropriate value to use. In the case where we caught this bug, the values of the joined-table's column looked confusingly similar to the values possible in the top-level table's column, making this even harder to debug.

You'll notice there isn't a test case: I think the setup for a test case that exhibits the behavior would be larger than the codebase of fob. I tested this manually where we found the bug and it does correct the page-break values. I suppose I can try writing a test case if you feel strongly about it though.