### PR TITLE
Remove the dynamic assumption of table field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 - 2022-03-10
+
+### Changed
+
+- Added the ability to paginate with order by fragments, when the same query
+  fragment is a select. See tests for example.
+
 ## 0.5.1 - 2022-02-04
 
 ### Fixed

--- a/lib/fob.ex
+++ b/lib/fob.ex
@@ -155,49 +155,53 @@ defmodule Fob do
   defp apply_basic_comparison(
          %PageBreak{
            direction: direction,
+           table: table,
            value: value,
-           field_or_alias: field_or_alias
+           column: column
          },
          :strict
        )
        when direction in @ascending do
-    dynamic(^field_or_alias > ^value)
+    dynamic([{t, table}], field(t, ^column) > ^value)
   end
 
   defp apply_basic_comparison(
          %PageBreak{
            direction: direction,
+           table: table,
            value: value,
-           field_or_alias: field_or_alias
+           column: column
          },
          :lenient
        )
        when direction in @ascending do
-    dynamic(^field_or_alias >= ^value)
+    dynamic([{t, table}], field(t, ^column) >= ^value)
   end
 
   defp apply_basic_comparison(
          %PageBreak{
            direction: direction,
+           table: table,
            value: value,
-           field_or_alias: field_or_alias
+           column: column
          },
          :strict
        )
        when direction in @descending do
-    dynamic([{t, table}], ^field_or_alias < ^value)
+    dynamic([{t, table}], field(t, ^column) < ^value)
   end
 
   defp apply_basic_comparison(
          %PageBreak{
            direction: direction,
+           table: table,
            value: value,
-           field_or_alias: field_or_alias
+           column: column
          },
          :lenient
        )
        when direction in @descending do
-    dynamic(^field_or_alias <= ^value)
+    dynamic([{t, table}], field(t, ^column) <= ^value)
   end
 
   @doc since: "0.1.0"

--- a/lib/fob/fragment_builder.ex
+++ b/lib/fob/fragment_builder.ex
@@ -1,0 +1,20 @@
+defmodule Fob.FragmentBuilder do
+  @moduledoc false
+  @spec build([Macro.t()], Macro.t(), Macro.t(), Macro.Env.t()) :: Macro.t()
+  def build(binding, expr, params, env) do
+    quote do
+      %Ecto.Query.DynamicExpr{
+        fun: fn query ->
+          {unquote(expr), unquote(params), []}
+        end,
+        binding: unquote(Macro.escape(binding)),
+        file: unquote(env.file),
+        line: unquote(env.line)
+      }
+    end
+  end
+
+  defmacro build_from_existing(binding \\ [], expr, params) do
+    build(binding, expr, params, __CALLER__)
+  end
+end

--- a/lib/fob/fragment_builder.ex
+++ b/lib/fob/fragment_builder.ex
@@ -1,7 +1,5 @@
 defmodule Fob.FragmentBuilder do
   @moduledoc false
-  # Wyno cover? 
-  # chaps-ignore-start
   @spec build([Macro.t()], Macro.t(), Macro.t(), Macro.Env.t()) :: Macro.t()
   def build(binding, expr, params, env) do
     quote do
@@ -19,8 +17,6 @@ defmodule Fob.FragmentBuilder do
   defmacro build_from_existing(binding \\ [], expr) do
     build(binding, expr, [], __CALLER__)
   end
-
-  # chaps-ignore-start
 
   def table_for_fragment({:fragment, [], _} = frag) do
     Macro.prewalk(frag, nil, fn ast, acc ->

--- a/lib/fob/fragment_builder.ex
+++ b/lib/fob/fragment_builder.ex
@@ -1,5 +1,7 @@
 defmodule Fob.FragmentBuilder do
   @moduledoc false
+  # Wyno cover? 
+  # chaps-ignore-start
   @spec build([Macro.t()], Macro.t(), Macro.t(), Macro.Env.t()) :: Macro.t()
   def build(binding, expr, params, env) do
     quote do
@@ -17,4 +19,6 @@ defmodule Fob.FragmentBuilder do
   defmacro build_from_existing(binding \\ [], expr, params) do
     build(binding, expr, params, __CALLER__)
   end
+
+  # chaps-ignore-start
 end

--- a/lib/fob/page_break.ex
+++ b/lib/fob/page_break.ex
@@ -14,7 +14,8 @@ defmodule Fob.PageBreak do
 
   @type t :: %__MODULE__{}
 
-  defstruct ~w[column value table direction]a
+  @enforce_keys [:field_or_alias]
+  defstruct ~w[column value table direction field_or_alias]a
 
   def add_query_info(nil, _), do: nil
 

--- a/test/fob/complex_order_by_test.exs
+++ b/test/fob/complex_order_by_test.exs
@@ -62,9 +62,9 @@ defmodule Fob.ComplexOrderByTest do
           s in c.schema,
           select: %{
             id: s.id,
-            virtual_column: fragment("(?) as virtual_column", s.id)
+            virtual_column: fragment("(? % 2)", s.id)
           },
-          order_by: [desc: fragment("virtual_column"), asc: s.id]
+          order_by: [desc: fragment("(? % 2)", s.id), desc: s.id]
         ),
         c.repo,
         nil,
@@ -72,10 +72,10 @@ defmodule Fob.ComplexOrderByTest do
       )
 
     assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == Enum.to_list(20..11)
+    assert Enum.map(records, & &1.id) == [19, 17, 15, 13, 11, 9, 7, 5, 3, 1]
 
     assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == Enum.to_list(10..1)
+    assert Enum.map(records, & &1.id) == [20, 18, 16, 14, 12, 10, 8, 6, 4, 2]
 
     assert {[], _cursor} = Cursor.next(cursor)
   end

--- a/test/fob/complex_order_by_test.exs
+++ b/test/fob/complex_order_by_test.exs
@@ -1,0 +1,82 @@
+defmodule Fob.ComplexOrderByTest do
+  use Fob.RepoCase
+
+  @moduledoc """
+  Tests functionality where a query is sorted by a complex fragment
+  """
+
+  alias Fob.Cursor
+  alias Ecto.Multi
+
+  setup do
+    [schema: SimplePrimaryKeySchema, repo: Fob.Repo]
+  end
+
+  setup c do
+    records = for n <- 1..20, do: %{id: n}
+
+    Multi.new()
+    |> Multi.insert_all(:seeds, c.schema, records)
+    |> c.repo.transaction()
+
+    :ok
+  end
+
+  test "when sorting ascending with fragment, we can get each page", c do
+    cursor =
+      Cursor.new(
+        from(
+          s in c.schema,
+          select: %{
+            id: s.id,
+            virtual_column: fragment("(? % 2)", s.id)
+          },
+          order_by: [asc: fragment("(? % 2)", s.id), asc: s.id]
+        ),
+        c.repo,
+        _initial_page_breaks = nil,
+        5
+      )
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [2, 4, 6, 8, 10]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [12, 14, 16, 18, 20]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [1, 3, 5, 7, 9]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [11, 13, 15, 17, 19]
+
+    # end of the data set
+    assert {[], _cursor} = Cursor.next(cursor)
+  end
+
+  test "when sorting descending with fragment, the records are in reverse order",
+       c do
+    cursor =
+      Cursor.new(
+        from(
+          s in c.schema,
+          select: %{
+            id: s.id,
+            virtual_column: fragment("(?) as virtual_column", s.id)
+          },
+          order_by: [desc: fragment("virtual_column"), asc: s.id]
+        ),
+        c.repo,
+        nil,
+        10
+      )
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == Enum.to_list(20..11)
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == Enum.to_list(10..1)
+
+    assert {[], _cursor} = Cursor.next(cursor)
+  end
+end

--- a/test/fob/fragment_builder_test.exs
+++ b/test/fob/fragment_builder_test.exs
@@ -1,0 +1,25 @@
+defmodule Fob.FragmentBuilderTest do
+  use ExUnit.Case
+
+  import Ecto.Query
+  import Ecto.Query
+  require Fob.FragmentBuilder
+
+  test "fragement builder builds dynamic query" do
+    query =
+      from(
+        s in "schema",
+        as: :s,
+        select: %{
+          virtual_column: fragment("(? % 2)", s.id)
+        },
+        order_by: [asc: fragment("(? % 2)", s.id)]
+      )
+
+    %{expr: [{_direction, frag}]} = hd(query.order_bys)
+
+    dyn = Fob.FragmentBuilder.build_from_existing([s: s], frag)
+
+    assert %Ecto.Query.DynamicExpr{} = dyn
+  end
+end


### PR DESCRIPTION
# Support complex order by statements via fragment + SQL AS

An example query utilizing bare `AS` in select:
```elixir
query
|> select_merge([tbl: t], %{ virtual_column: fragment("?[1]->>'json_column' AS virtual_column", t.some_column) })
|> order_by(desc: fragment("virtual_column"))
```
**UPDATE** the `AS` approach won't work without further parsing of the select query which don't think is a good plan, I'm only going to support the 'matching select' approach below.

An example query same expr:
```elixir
query
|> select_merge([tbl: t], %{ virtual_column: fragment("?[1]->>'json_column'", t.some_column) })
|> order_by([tbl: t], desc: fragment("?[1]->>'json_column'", t.some_column))
```

This should allow arbitrarily complex order by expressions by looking up the select statement with the matching expr as the order by or via a select result matching an SQL `AS` expr

---

- Adds field_or_alias concept to ordering and page break that holds the
  previously held assumption of table column in as expr in the structs
- Utilizes the field_or_alias for the Fob apply_keyset_comparison
  dynamics

---

### TODO
- [X] Test locally through Haste to verify it didn't break anything See PR #9 
- ~[ ] Profit?~