### PR TITLE
Field keystone to non dynmic for casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 - 2022-03-14
+
+### Fixed
+
+- Fixed some cases where date / datetime casting suffered from the dynamic
+  expressions approach. The original Ecto integration queries now run unless a
+  fragment if supplied.
+
 ## 0.6.0 - 2022-03-10
 
 ### Changed

--- a/lib/fob.ex
+++ b/lib/fob.ex
@@ -76,8 +76,6 @@ defmodule Fob do
 
   defp apply_keyset_comparison_field(page_break, acc)
 
-  # --- value is nil
-
   defp apply_keyset_comparison_field(
          %PageBreak{
            direction: direction,
@@ -198,8 +196,6 @@ defmodule Fob do
         (^expression |> is_nil() and ^acc)
     )
   end
-
-  # --- value is non-nil
 
   defp apply_keyset_comparison_expression(
          %PageBreak{

--- a/lib/fob.ex
+++ b/lib/fob.ex
@@ -39,13 +39,13 @@ defmodule Fob do
     limit(queryable, ^page_size)
   end
 
-  defp route_keyset_comparison(routeable_page_break, accumulator) do
+  defp route_keyset_comparison(routeable_page_break, acc) do
     case routeable_page_break do
       {page_break, nil} ->
-        apply_keyset_comparison_field(page_break, accumulator)
+        apply_keyset_comparison_field(page_break, acc)
 
       {page_break, expr} ->
-        apply_keyset_comparison_alias(page_break, expr, accumulator)
+        apply_keyset_comparison_expression(page_break, expr, acc)
     end
   end
 
@@ -74,7 +74,7 @@ defmodule Fob do
     where(query, ^where_clause)
   end
 
-  defp apply_keyset_comparison_field(page_break, accumulator)
+  defp apply_keyset_comparison_field(page_break, acc)
 
   # --- value is nil
 
@@ -172,7 +172,7 @@ defmodule Fob do
     )
   end
 
-  defp apply_keyset_comparison_alias(
+  defp apply_keyset_comparison_expression(
          %PageBreak{
            direction: direction,
            value: nil
@@ -184,7 +184,7 @@ defmodule Fob do
     dynamic(^expression |> is_nil() and ^acc)
   end
 
-  defp apply_keyset_comparison_alias(
+  defp apply_keyset_comparison_expression(
          %PageBreak{
            direction: direction,
            value: nil
@@ -201,7 +201,7 @@ defmodule Fob do
 
   # --- value is non-nil
 
-  defp apply_keyset_comparison_alias(
+  defp apply_keyset_comparison_expression(
          %PageBreak{
            direction: direction,
            value: value
@@ -216,7 +216,7 @@ defmodule Fob do
     )
   end
 
-  defp apply_keyset_comparison_alias(
+  defp apply_keyset_comparison_expression(
          %PageBreak{
            direction: :asc_nulls_first,
            value: value
@@ -227,7 +227,7 @@ defmodule Fob do
     dynamic(^expression > ^value or (^expression == ^value and ^acc))
   end
 
-  defp apply_keyset_comparison_alias(
+  defp apply_keyset_comparison_expression(
          %PageBreak{
            direction: direction,
            value: value
@@ -239,7 +239,7 @@ defmodule Fob do
     dynamic(^expression < ^value or (^expression == ^value and ^acc))
   end
 
-  defp apply_keyset_comparison_alias(
+  defp apply_keyset_comparison_expression(
          %PageBreak{
            direction: :desc_nulls_last,
            value: value

--- a/lib/fob.ex
+++ b/lib/fob.ex
@@ -67,12 +67,25 @@ defmodule Fob do
   defp apply_keyset_comparison(page_break, accumulator)
 
   # --- value is nil
+  #
+  defp apply_keyset_comparison(
+         {%PageBreak{
+            direction: direction,
+            value: nil,
+            table: table,
+            column: column
+          }, :field},
+         acc
+       )
+       when direction in [:asc, :asc_nulls_last, :desc_nulls_last] do
+    dynamic([{t, table}], field(t, ^column) |> is_nil() and ^acc)
+  end
 
   defp apply_keyset_comparison(
          {%PageBreak{
             direction: direction,
             value: nil
-          }, field_or_alias},
+          }, {:alias, field_or_alias}},
          acc
        )
        when direction in [:asc, :asc_nulls_last, :desc_nulls_last] do
@@ -82,8 +95,25 @@ defmodule Fob do
   defp apply_keyset_comparison(
          {%PageBreak{
             direction: direction,
+            value: nil,
+            table: table,
+            column: column
+          }, :field},
+         acc
+       )
+       when direction in [:desc, :desc_nulls_first, :asc_nulls_first] do
+    dynamic(
+      [{t, table}],
+      not is_nil(field(t, ^column)) or
+        (field(t, ^column) |> is_nil() and ^acc)
+    )
+  end
+
+  defp apply_keyset_comparison(
+         {%PageBreak{
+            direction: direction,
             value: nil
-          }, field_or_alias},
+          }, {:alias, field_or_alias}},
          acc
        )
        when direction in [:desc, :desc_nulls_first, :asc_nulls_first] do
@@ -98,8 +128,25 @@ defmodule Fob do
   defp apply_keyset_comparison(
          {%PageBreak{
             direction: direction,
+            value: value,
+            table: table,
+            column: column
+          }, :field},
+         acc
+       )
+       when direction in [:asc, :asc_nulls_last] do
+    dynamic(
+      [{t, table}],
+      field(t, ^column) > ^value or field(t, ^column) |> is_nil() or
+        (field(t, ^column) == ^value and ^acc)
+    )
+  end
+
+  defp apply_keyset_comparison(
+         {%PageBreak{
+            direction: direction,
             value: value
-          }, field_or_alias},
+          }, {:alias, field_or_alias}},
          acc
        )
        when direction in [:asc, :asc_nulls_last] do
@@ -112,8 +159,23 @@ defmodule Fob do
   defp apply_keyset_comparison(
          {%PageBreak{
             direction: :asc_nulls_first,
+            value: value,
+            table: table,
+            column: column
+          }, :field},
+         acc
+       ) do
+    dynamic(
+      [{t, table}],
+      field(t, ^column) > ^value or (field(t, ^column) == ^value and ^acc)
+    )
+  end
+
+  defp apply_keyset_comparison(
+         {%PageBreak{
+            direction: :asc_nulls_first,
             value: value
-          }, field_or_alias},
+          }, {:alias, field_or_alias}},
          acc
        ) do
     dynamic(^field_or_alias > ^value or (^field_or_alias == ^value and ^acc))
@@ -122,8 +184,24 @@ defmodule Fob do
   defp apply_keyset_comparison(
          {%PageBreak{
             direction: direction,
+            value: value,
+            table: table,
+            column: column
+          }, :field},
+         acc
+       )
+       when direction in [:desc, :desc_nulls_first] do
+    dynamic(
+      [{t, table}],
+      field(t, ^column) < ^value or (field(t, ^column) == ^value and ^acc)
+    )
+  end
+
+  defp apply_keyset_comparison(
+         {%PageBreak{
+            direction: direction,
             value: value
-          }, field_or_alias},
+          }, {:alias, field_or_alias}},
          acc
        )
        when direction in [:desc, :desc_nulls_first] do
@@ -133,8 +211,24 @@ defmodule Fob do
   defp apply_keyset_comparison(
          {%PageBreak{
             direction: :desc_nulls_last,
+            value: value,
+            table: table,
+            column: column
+          }, :field},
+         acc
+       ) do
+    dynamic(
+      [{t, table}],
+      field(t, ^column) < ^value or field(t, ^column) |> is_nil() or
+        (field(t, ^column) == ^value and ^acc)
+    )
+  end
+
+  defp apply_keyset_comparison(
+         {%PageBreak{
+            direction: :desc_nulls_last,
             value: value
-          }, field_or_alias},
+          }, {:alias, field_or_alias}},
          acc
        ) do
     dynamic(

--- a/lib/fob.ex
+++ b/lib/fob.ex
@@ -29,7 +29,7 @@ defmodule Fob do
     page_breaks = PageBreak.add_query_info(page_breaks, query)
 
     query
-    |> apply_keyset_comparison(page_breaks, :strict)
+    |> route_keyset_comparison(page_breaks, :strict)
     |> apply_limit(page_size)
   end
 
@@ -39,7 +39,17 @@ defmodule Fob do
     limit(queryable, ^page_size)
   end
 
-  defp apply_keyset_comparison(
+  defp route_keyset_comparison(routeable_page_break, accumulator) do
+    case routeable_page_break do
+      {page_break, nil} ->
+        apply_keyset_comparison_field(page_break, accumulator)
+
+      {page_break, expr} ->
+        apply_keyset_comparison_alias(page_break, expr, accumulator)
+    end
+  end
+
+  defp route_keyset_comparison(
          %Ecto.Query{} = query,
          nil = _page_breaks,
          _comparison_strictness
@@ -47,7 +57,7 @@ defmodule Fob do
     query
   end
 
-  defp apply_keyset_comparison(
+  defp route_keyset_comparison(
          %Ecto.Query{} = query,
          [_ | _] = page_breaks,
          comparison_strictness
@@ -58,47 +68,36 @@ defmodule Fob do
 
     where_clause =
       remaining_breaks
-      |> PageBreak.wrap_field_or_alias(query)
-      |> Enum.reduce(initial_acc, &apply_keyset_comparison/2)
+      |> PageBreak.wrap_to_routeable(query)
+      |> Enum.reduce(initial_acc, &route_keyset_comparison/2)
 
     where(query, ^where_clause)
   end
 
-  defp apply_keyset_comparison(page_break, accumulator)
+  defp apply_keyset_comparison_field(page_break, accumulator)
 
   # --- value is nil
-  #
-  defp apply_keyset_comparison(
-         {%PageBreak{
-            direction: direction,
-            value: nil,
-            table: table,
-            column: column
-          }, :field},
+
+  defp apply_keyset_comparison_field(
+         %PageBreak{
+           direction: direction,
+           value: nil,
+           table: table,
+           column: column
+         },
          acc
        )
        when direction in [:asc, :asc_nulls_last, :desc_nulls_last] do
     dynamic([{t, table}], field(t, ^column) |> is_nil() and ^acc)
   end
 
-  defp apply_keyset_comparison(
-         {%PageBreak{
-            direction: direction,
-            value: nil
-          }, {:alias, field_or_alias}},
-         acc
-       )
-       when direction in [:asc, :asc_nulls_last, :desc_nulls_last] do
-    dynamic(^field_or_alias |> is_nil() and ^acc)
-  end
-
-  defp apply_keyset_comparison(
-         {%PageBreak{
-            direction: direction,
-            value: nil,
-            table: table,
-            column: column
-          }, :field},
+  defp apply_keyset_comparison_field(
+         %PageBreak{
+           direction: direction,
+           value: nil,
+           table: table,
+           column: column
+         },
          acc
        )
        when direction in [:desc, :desc_nulls_first, :asc_nulls_first] do
@@ -109,29 +108,13 @@ defmodule Fob do
     )
   end
 
-  defp apply_keyset_comparison(
-         {%PageBreak{
-            direction: direction,
-            value: nil
-          }, {:alias, field_or_alias}},
-         acc
-       )
-       when direction in [:desc, :desc_nulls_first, :asc_nulls_first] do
-    dynamic(
-      not is_nil(^field_or_alias) or
-        (^field_or_alias |> is_nil() and ^acc)
-    )
-  end
-
-  # --- value is non-nil
-
-  defp apply_keyset_comparison(
-         {%PageBreak{
-            direction: direction,
-            value: value,
-            table: table,
-            column: column
-          }, :field},
+  defp apply_keyset_comparison_field(
+         %PageBreak{
+           direction: direction,
+           value: value,
+           table: table,
+           column: column
+         },
          acc
        )
        when direction in [:asc, :asc_nulls_last] do
@@ -142,27 +125,13 @@ defmodule Fob do
     )
   end
 
-  defp apply_keyset_comparison(
-         {%PageBreak{
-            direction: direction,
-            value: value
-          }, {:alias, field_or_alias}},
-         acc
-       )
-       when direction in [:asc, :asc_nulls_last] do
-    dynamic(
-      ^field_or_alias > ^value or ^field_or_alias |> is_nil() or
-        (^field_or_alias == ^value and ^acc)
-    )
-  end
-
-  defp apply_keyset_comparison(
-         {%PageBreak{
-            direction: :asc_nulls_first,
-            value: value,
-            table: table,
-            column: column
-          }, :field},
+  defp apply_keyset_comparison_field(
+         %PageBreak{
+           direction: :asc_nulls_first,
+           value: value,
+           table: table,
+           column: column
+         },
          acc
        ) do
     dynamic(
@@ -171,23 +140,13 @@ defmodule Fob do
     )
   end
 
-  defp apply_keyset_comparison(
-         {%PageBreak{
-            direction: :asc_nulls_first,
-            value: value
-          }, {:alias, field_or_alias}},
-         acc
-       ) do
-    dynamic(^field_or_alias > ^value or (^field_or_alias == ^value and ^acc))
-  end
-
-  defp apply_keyset_comparison(
-         {%PageBreak{
-            direction: direction,
-            value: value,
-            table: table,
-            column: column
-          }, :field},
+  defp apply_keyset_comparison_field(
+         %PageBreak{
+           direction: direction,
+           value: value,
+           table: table,
+           column: column
+         },
          acc
        )
        when direction in [:desc, :desc_nulls_first] do
@@ -197,24 +156,13 @@ defmodule Fob do
     )
   end
 
-  defp apply_keyset_comparison(
-         {%PageBreak{
-            direction: direction,
-            value: value
-          }, {:alias, field_or_alias}},
-         acc
-       )
-       when direction in [:desc, :desc_nulls_first] do
-    dynamic(^field_or_alias < ^value or (^field_or_alias == ^value and ^acc))
-  end
-
-  defp apply_keyset_comparison(
-         {%PageBreak{
-            direction: :desc_nulls_last,
-            value: value,
-            table: table,
-            column: column
-          }, :field},
+  defp apply_keyset_comparison_field(
+         %PageBreak{
+           direction: :desc_nulls_last,
+           value: value,
+           table: table,
+           column: column
+         },
          acc
        ) do
     dynamic(
@@ -224,16 +172,84 @@ defmodule Fob do
     )
   end
 
-  defp apply_keyset_comparison(
-         {%PageBreak{
-            direction: :desc_nulls_last,
-            value: value
-          }, {:alias, field_or_alias}},
+  defp apply_keyset_comparison_alias(
+         %PageBreak{
+           direction: direction,
+           value: nil
+         },
+         expression,
+         acc
+       )
+       when direction in [:asc, :asc_nulls_last, :desc_nulls_last] do
+    dynamic(^expression |> is_nil() and ^acc)
+  end
+
+  defp apply_keyset_comparison_alias(
+         %PageBreak{
+           direction: direction,
+           value: nil
+         },
+         expression,
+         acc
+       )
+       when direction in [:desc, :desc_nulls_first, :asc_nulls_first] do
+    dynamic(
+      not is_nil(^expression) or
+        (^expression |> is_nil() and ^acc)
+    )
+  end
+
+  # --- value is non-nil
+
+  defp apply_keyset_comparison_alias(
+         %PageBreak{
+           direction: direction,
+           value: value
+         },
+         expression,
+         acc
+       )
+       when direction in [:asc, :asc_nulls_last] do
+    dynamic(
+      ^expression > ^value or ^expression |> is_nil() or
+        (^expression == ^value and ^acc)
+    )
+  end
+
+  defp apply_keyset_comparison_alias(
+         %PageBreak{
+           direction: :asc_nulls_first,
+           value: value
+         },
+         expression,
+         acc
+       ) do
+    dynamic(^expression > ^value or (^expression == ^value and ^acc))
+  end
+
+  defp apply_keyset_comparison_alias(
+         %PageBreak{
+           direction: direction,
+           value: value
+         },
+         expression,
+         acc
+       )
+       when direction in [:desc, :desc_nulls_first] do
+    dynamic(^expression < ^value or (^expression == ^value and ^acc))
+  end
+
+  defp apply_keyset_comparison_alias(
+         %PageBreak{
+           direction: :desc_nulls_last,
+           value: value
+         },
+         expression,
          acc
        ) do
     dynamic(
-      ^field_or_alias < ^value or ^field_or_alias |> is_nil() or
-        (^field_or_alias == ^value and ^acc)
+      ^expression < ^value or ^expression |> is_nil() or
+        (^expression == ^value and ^acc)
     )
   end
 
@@ -330,8 +346,8 @@ defmodule Fob do
     stop = stop |> PageBreak.add_query_info(query) |> reverse()
 
     query
-    |> apply_keyset_comparison(start, :lenient)
-    |> apply_keyset_comparison(stop, :lenient)
+    |> route_keyset_comparison(start, :lenient)
+    |> route_keyset_comparison(stop, :lenient)
   end
 
   defp reverse(nil), do: nil

--- a/lib/fob/ordering.ex
+++ b/lib/fob/ordering.ex
@@ -9,15 +9,16 @@ defmodule Fob.Ordering do
   require Fob.FragmentBuilder
 
   @typep table :: nil | non_neg_integer()
+  @typep expr :: Macro.t()
 
   @type t :: %__MODULE__{
           table: table(),
           column: atom(),
           direction: :asc | :desc,
-          field_or_alias: any()
+          maybe_expression: nil | expr()
         }
 
-  defstruct ~w[table column direction field_or_alias]a
+  defstruct ~w[table column direction maybe_expression]a
 
   @spec config(%Query{}) :: [t()]
   def config(%Query{order_bys: orderings} = query) do
@@ -38,7 +39,7 @@ defmodule Fob.Ordering do
       direction: direction,
       column: column,
       table: table,
-      field_or_alias: :field
+      maybe_expression: nil
     }
   end
 
@@ -50,7 +51,7 @@ defmodule Fob.Ordering do
 
     column = FragmentBuilder.column_for_query_fragment(frag, query)
 
-    field_or_alias =
+    dyn_expression =
       Fob.FragmentBuilder.build_from_existing(
         [{t, table}],
         frag
@@ -60,7 +61,7 @@ defmodule Fob.Ordering do
       direction: direction,
       column: column,
       table: table,
-      field_or_alias: {:alias, field_or_alias}
+      maybe_expression: dyn_expression
     }
   end
 

--- a/lib/fob/ordering.ex
+++ b/lib/fob/ordering.ex
@@ -5,7 +5,6 @@ defmodule Fob.Ordering do
   # in a query
 
   alias Ecto.Query
-  import Ecto.Query
   alias Fob.FragmentBuilder
   require Fob.FragmentBuilder
 
@@ -39,7 +38,7 @@ defmodule Fob.Ordering do
       direction: direction,
       column: column,
       table: table,
-      field_or_alias: dynamic([{t, table}], field(t, ^column))
+      field_or_alias: :field
     }
   end
 
@@ -61,7 +60,7 @@ defmodule Fob.Ordering do
       direction: direction,
       column: column,
       table: table,
-      field_or_alias: field_or_alias
+      field_or_alias: {:alias, field_or_alias}
     }
   end
 

--- a/lib/fob/page_break.ex
+++ b/lib/fob/page_break.ex
@@ -31,16 +31,16 @@ defmodule Fob.PageBreak do
     %__MODULE__{page_break | table: order.table, direction: order.direction}
   end
 
-  def wrap_field_or_alias(page_breaks, %Ecto.Query{} = query)
+  def wrap_to_routeable(page_breaks, %Ecto.Query{} = query)
       when is_list(page_breaks) do
     ordering_config = Ordering.config(query)
 
-    Enum.map(page_breaks, &wrap_field_or_alias(&1, ordering_config))
+    Enum.map(page_breaks, &wrap_to_routeable(&1, ordering_config))
   end
 
-  def wrap_field_or_alias(%{column: column} = page_break, ordering_config) do
+  def wrap_to_routeable(%{column: column} = page_break, ordering_config) do
     order = Enum.find(ordering_config, fn order -> column == order.column end)
-    {page_break, order.field_or_alias}
+    {page_break, order.maybe_expression}
   end
 
   @doc since: "0.2.0"

--- a/test/fob/complex_order_by_test.exs
+++ b/test/fob/complex_order_by_test.exs
@@ -54,72 +54,6 @@ defmodule Fob.ComplexOrderByTest do
     assert {[], _cursor} = Cursor.next(cursor)
   end
 
-  test "when sorting ascending nulls first with fragment, we can get each page",
-       c do
-    cursor =
-      Cursor.new(
-        from(
-          s in c.schema,
-          select: %{
-            id: s.id,
-            virtual_column: fragment("(? % 2)", s.id)
-          },
-          order_by: [asc_nulls_first: fragment("(? % 2)", s.id), asc: s.id]
-        ),
-        c.repo,
-        _initial_page_breaks = nil,
-        5
-      )
-
-    assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == [2, 4, 6, 8, 10]
-
-    assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == [12, 14, 16, 18, 20]
-
-    assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == [1, 3, 5, 7, 9]
-
-    assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == [11, 13, 15, 17, 19]
-
-    # end of the data set
-    assert {[], _cursor} = Cursor.next(cursor)
-  end
-
-  test "when sorting ascending nulls last with fragment, we can get each page",
-       c do
-    cursor =
-      Cursor.new(
-        from(
-          s in c.schema,
-          select: %{
-            id: s.id,
-            virtual_column: fragment("(? % 2)", s.id)
-          },
-          order_by: [asc_nulls_last: fragment("(? % 2)", s.id), asc: s.id]
-        ),
-        c.repo,
-        _initial_page_breaks = nil,
-        5
-      )
-
-    assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == [2, 4, 6, 8, 10]
-
-    assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == [12, 14, 16, 18, 20]
-
-    assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == [1, 3, 5, 7, 9]
-
-    assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == [11, 13, 15, 17, 19]
-
-    # end of the data set
-    assert {[], _cursor} = Cursor.next(cursor)
-  end
-
   test "when sorting descending with fragment, the records are in reverse order",
        c do
     cursor =
@@ -131,58 +65,6 @@ defmodule Fob.ComplexOrderByTest do
             virtual_column: fragment("(? % 2)", s.id)
           },
           order_by: [desc: fragment("(? % 2)", s.id), desc: s.id]
-        ),
-        c.repo,
-        nil,
-        10
-      )
-
-    assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == [19, 17, 15, 13, 11, 9, 7, 5, 3, 1]
-
-    assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == [20, 18, 16, 14, 12, 10, 8, 6, 4, 2]
-
-    assert {[], _cursor} = Cursor.next(cursor)
-  end
-
-  test "when sorting descending nulls first with fragment, the records are in reverse order",
-       c do
-    cursor =
-      Cursor.new(
-        from(
-          s in c.schema,
-          select: %{
-            id: s.id,
-            virtual_column: fragment("(? % 2)", s.id)
-          },
-          order_by: [desc_nulls_first: fragment("(? % 2)", s.id), desc: s.id]
-        ),
-        c.repo,
-        nil,
-        10
-      )
-
-    assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == [19, 17, 15, 13, 11, 9, 7, 5, 3, 1]
-
-    assert {records, cursor} = Cursor.next(cursor)
-    assert Enum.map(records, & &1.id) == [20, 18, 16, 14, 12, 10, 8, 6, 4, 2]
-
-    assert {[], _cursor} = Cursor.next(cursor)
-  end
-
-  test "when sorting descending nulls last with fragment, the records are in reverse order",
-       c do
-    cursor =
-      Cursor.new(
-        from(
-          s in c.schema,
-          select: %{
-            id: s.id,
-            virtual_column: fragment("(? % 2)", s.id)
-          },
-          order_by: [desc_nulls_last: fragment("(? % 2)", s.id), desc: s.id]
         ),
         c.repo,
         nil,

--- a/test/fob/complex_order_by_test.exs
+++ b/test/fob/complex_order_by_test.exs
@@ -54,6 +54,72 @@ defmodule Fob.ComplexOrderByTest do
     assert {[], _cursor} = Cursor.next(cursor)
   end
 
+  test "when sorting ascending nulls first with fragment, we can get each page",
+       c do
+    cursor =
+      Cursor.new(
+        from(
+          s in c.schema,
+          select: %{
+            id: s.id,
+            virtual_column: fragment("(? % 2)", s.id)
+          },
+          order_by: [asc_nulls_first: fragment("(? % 2)", s.id), asc: s.id]
+        ),
+        c.repo,
+        _initial_page_breaks = nil,
+        5
+      )
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [2, 4, 6, 8, 10]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [12, 14, 16, 18, 20]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [1, 3, 5, 7, 9]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [11, 13, 15, 17, 19]
+
+    # end of the data set
+    assert {[], _cursor} = Cursor.next(cursor)
+  end
+
+  test "when sorting ascending nulls last with fragment, we can get each page",
+       c do
+    cursor =
+      Cursor.new(
+        from(
+          s in c.schema,
+          select: %{
+            id: s.id,
+            virtual_column: fragment("(? % 2)", s.id)
+          },
+          order_by: [asc_nulls_last: fragment("(? % 2)", s.id), asc: s.id]
+        ),
+        c.repo,
+        _initial_page_breaks = nil,
+        5
+      )
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [2, 4, 6, 8, 10]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [12, 14, 16, 18, 20]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [1, 3, 5, 7, 9]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [11, 13, 15, 17, 19]
+
+    # end of the data set
+    assert {[], _cursor} = Cursor.next(cursor)
+  end
+
   test "when sorting descending with fragment, the records are in reverse order",
        c do
     cursor =
@@ -65,6 +131,58 @@ defmodule Fob.ComplexOrderByTest do
             virtual_column: fragment("(? % 2)", s.id)
           },
           order_by: [desc: fragment("(? % 2)", s.id), desc: s.id]
+        ),
+        c.repo,
+        nil,
+        10
+      )
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [19, 17, 15, 13, 11, 9, 7, 5, 3, 1]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [20, 18, 16, 14, 12, 10, 8, 6, 4, 2]
+
+    assert {[], _cursor} = Cursor.next(cursor)
+  end
+
+  test "when sorting descending nulls first with fragment, the records are in reverse order",
+       c do
+    cursor =
+      Cursor.new(
+        from(
+          s in c.schema,
+          select: %{
+            id: s.id,
+            virtual_column: fragment("(? % 2)", s.id)
+          },
+          order_by: [desc_nulls_first: fragment("(? % 2)", s.id), desc: s.id]
+        ),
+        c.repo,
+        nil,
+        10
+      )
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [19, 17, 15, 13, 11, 9, 7, 5, 3, 1]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [20, 18, 16, 14, 12, 10, 8, 6, 4, 2]
+
+    assert {[], _cursor} = Cursor.next(cursor)
+  end
+
+  test "when sorting descending nulls last with fragment, the records are in reverse order",
+       c do
+    cursor =
+      Cursor.new(
+        from(
+          s in c.schema,
+          select: %{
+            id: s.id,
+            virtual_column: fragment("(? % 2)", s.id)
+          },
+          order_by: [desc_nulls_last: fragment("(? % 2)", s.id), desc: s.id]
         ),
         c.repo,
         nil,

--- a/test/fob/nillable_complex_order_by_test.exs
+++ b/test/fob/nillable_complex_order_by_test.exs
@@ -1,0 +1,148 @@
+defmodule Fob.NillableComplexOrderByTest do
+  use Fob.RepoCase
+  alias Fob.Cursor
+  alias Ecto.Multi
+
+  @day_of_week_sort "(EXTRACT(DOW FROM ?))"
+
+  setup do
+    [schema: NillableSchema, repo: Fob.Repo]
+  end
+
+  setup c do
+    records = c.schema.seed()
+
+    Multi.new()
+    |> Multi.insert_all(:seeds, c.schema, records)
+    |> c.repo.transaction()
+
+    :ok
+  end
+
+  test "when sorting ascending nulls first with fragment, we can get each page",
+       c do
+    cursor =
+      Cursor.new(
+        from(
+          s in c.schema,
+          select: %{
+            id: s.id,
+            virtual_column: fragment(@day_of_week_sort, s.date)
+          },
+          order_by: [
+            asc_nulls_first: fragment(@day_of_week_sort, s.date),
+            asc: s.id
+          ]
+        ),
+        c.repo,
+        _initial_page_breaks = nil,
+        5
+      )
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [6, 7, 8, 9, 10]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [11, 12, 13, 14, 4]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [5, 0, 1, 2, 3]
+
+    # end of the data set
+    assert {[], _cursor} = Cursor.next(cursor)
+  end
+
+  test "when sorting ascending nulls last with fragment, we can get each page",
+       c do
+    cursor =
+      Cursor.new(
+        from(
+          s in c.schema,
+          select: %{
+            id: s.id,
+            virtual_column: fragment(@day_of_week_sort, s.date)
+          },
+          order_by: [
+            asc_nulls_last: fragment(@day_of_week_sort, s.date),
+            asc: s.id
+          ]
+        ),
+        c.repo,
+        _initial_page_breaks = nil,
+        5
+      )
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [4, 5, 0, 1, 2]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [3, 6, 7, 8, 9]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [10, 11, 12, 13, 14]
+
+    # end of the data set
+    assert {[], _cursor} = Cursor.next(cursor)
+  end
+
+  test "when sorting descending nulls first with fragment, the records are in reverse order",
+       c do
+    cursor =
+      Cursor.new(
+        from(
+          s in c.schema,
+          select: %{
+            id: s.id,
+            virtual_column: fragment(@day_of_week_sort, s.date)
+          },
+          order_by: [
+            desc_nulls_first: fragment(@day_of_week_sort, s.date),
+            desc: s.id
+          ]
+        ),
+        c.repo,
+        nil,
+        10
+      )
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [14, 13, 12, 11, 10, 9, 8, 7, 6, 3]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [2, 1, 0, 5, 4]
+
+    assert {[], _cursor} = Cursor.next(cursor)
+  end
+
+  test "when sorting descending nulls last with fragment, the records are in reverse order",
+       c do
+    cursor =
+      Cursor.new(
+        from(
+          s in c.schema,
+          select: %{
+            id: s.id,
+            virtual_column: fragment(@day_of_week_sort, s.date)
+          },
+          order_by: [
+            desc_nulls_last: fragment(@day_of_week_sort, s.date),
+            desc: s.id
+          ]
+        ),
+        c.repo,
+        nil,
+        5
+      )
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [3, 2, 1, 0, 5]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [4, 14, 13, 12, 11]
+
+    assert {records, cursor} = Cursor.next(cursor)
+    assert Enum.map(records, & &1.id) == [10, 9, 8, 7, 6]
+
+    assert {[], _cursor} = Cursor.next(cursor)
+  end
+end

--- a/test/fob/nillable_test.exs
+++ b/test/fob/nillable_test.exs
@@ -23,30 +23,7 @@ defmodule Fob.NillableTest do
   end
 
   setup c do
-    records =
-      [
-        {~D[2020-02-12], 1},
-        {~D[2020-02-13], 2},
-        {~D[2020-02-14], 3},
-        {~D[2020-02-15], 4},
-        {~D[2020-02-16], 5},
-        # ---
-        {~D[2020-02-17], 6},
-        {nil, nil},
-        {nil, nil},
-        {nil, nil},
-        {nil, nil},
-        # ---
-        {nil, nil},
-        {nil, nil},
-        {nil, nil},
-        {nil, nil},
-        {nil, nil}
-      ]
-      |> Enum.with_index()
-      |> Enum.map(fn {{date, count}, index} ->
-        %{id: index, date: date, count: count}
-      end)
+    records = c.schema.seed()
 
     Multi.new()
     |> Multi.insert_all(:seeds, c.schema, records)

--- a/test/support/nillable_schema.ex
+++ b/test/support/nillable_schema.ex
@@ -10,4 +10,30 @@ defmodule NillableSchema do
     field :date, :date
     field :count, :integer
   end
+
+  def seed do
+    [
+      {~D[2020-02-12], 1},
+      {~D[2020-02-13], 2},
+      {~D[2020-02-14], 3},
+      {~D[2020-02-15], 4},
+      {~D[2020-02-16], 5},
+      # ---
+      {~D[2020-02-17], 6},
+      {nil, nil},
+      {nil, nil},
+      {nil, nil},
+      {nil, nil},
+      # ---
+      {nil, nil},
+      {nil, nil},
+      {nil, nil},
+      {nil, nil},
+      {nil, nil}
+    ]
+    |> Enum.with_index()
+    |> Enum.map(fn {{date, count}, index} ->
+      %{id: index, date: date, count: count}
+    end)
+  end
 end


### PR DESCRIPTION
Basic approach, revert to the previous field lookups for realized fields in comparisons. Only use the dynamic value lookup when utilizing a fragment.

# ~TODO~ TADONE
- [x] I think this means I should rename the `field_or_alias` to `field_or_dynamic`, thoughts?
- [x] I'm not sure I like the tuple structure after the update, it really needs a more consistent `either` type to be more readable and maintainable. Do I refactor those calls now?
- [x] Update the tests for null first / last to have a schema that can have nulls to show the behaviour is correct and to get coverage.
After some review and thought, the todo approach changed slightly.

1) we switched to `maybe_expression` instead of `field_or_dynamic`, and split the calls in fob by the two distinct branches of field and expression. 
2) The above addresses this mildly annoying function structure.
3) Added tests for null first and last on day of week date sorting.
