### PR TITLE
Capture columns bound in fragment

### DIFF
--- a/lib/fob.ex
+++ b/lib/fob.ex
@@ -342,13 +342,14 @@ defmodule Fob do
     selection_mapping = Ordering.selection_mapping(query)
 
     query
-    |> Ordering.columns()
-    |> Enum.map(fn {table, name} ->
+    |> Ordering.dependent_columns()
+    |> Enum.map(fn {table, name, dependent_columns} ->
       key = Map.get(selection_mapping, {table, name}, name)
 
       %PageBreak{
         column: name,
-        value: get_in(record, [Access.key(key)])
+        value: get_in(record, [Access.key(key)]),
+        dependent_columns: dependent_columns
       }
     end)
   end

--- a/lib/fob/fragment_builder.ex
+++ b/lib/fob/fragment_builder.ex
@@ -65,4 +65,19 @@ defmodule Fob.FragmentBuilder do
     end)
     |> elem(1)
   end
+
+  def columns_for_fragment({:fragment, [], _} = frag) do
+    Macro.prewalk(frag, [], fn ast, acc ->
+      case ast do
+        # all "columns" access with a `.`, I think this will be just the
+        # primary table in the query from the `[0]`
+        {:., [], [{:&, [], [0]}, column]} when is_atom(column) ->
+          {ast, [column | acc]}
+
+        _ ->
+          {ast, acc}
+      end
+    end)
+    |> elem(1)
+  end
 end

--- a/lib/fob/ordering.ex
+++ b/lib/fob/ordering.ex
@@ -71,6 +71,8 @@ defmodule Fob.Ordering do
     }
   end
 
+  # chaps-ignore-start
+  @deprecated "Use dependent_columns/1 instead"
   @spec columns(%Query{}) :: [{table(), atom(), any()}]
   def columns(%Query{} = query) do
     query
@@ -78,6 +80,8 @@ defmodule Fob.Ordering do
     |> Enum.map(&{&1.table, &1.column})
     |> Enum.uniq()
   end
+
+  # chaps-ignore-stop
 
   @spec dependent_columns(%Query{}) :: [{table(), atom(), any(), list(any())}]
   def dependent_columns(%Query{} = query) do

--- a/lib/fob/ordering.ex
+++ b/lib/fob/ordering.ex
@@ -15,10 +15,12 @@ defmodule Fob.Ordering do
           table: table(),
           column: atom(),
           direction: :asc | :desc,
-          maybe_expression: nil | expr()
+          maybe_expression: nil | expr(),
+          dependent_columns: list(atom())
         }
 
-  defstruct ~w[table column direction maybe_expression]a
+  defstruct ~w[table column direction maybe_expression]a ++
+              [dependent_columns: []]
 
   @spec config(%Query{}) :: [t()]
   def config(%Query{order_bys: orderings} = query) do
@@ -57,11 +59,14 @@ defmodule Fob.Ordering do
         frag
       )
 
+    dependent_columns = Fob.FragmentBuilder.columns_for_fragment(frag)
+
     %__MODULE__{
       direction: direction,
       column: column,
       table: table,
-      maybe_expression: dyn_expression
+      maybe_expression: dyn_expression,
+      dependent_columns: dependent_columns
     }
   end
 

--- a/lib/fob/ordering.ex
+++ b/lib/fob/ordering.ex
@@ -41,7 +41,8 @@ defmodule Fob.Ordering do
       direction: direction,
       column: column,
       table: table,
-      maybe_expression: nil
+      maybe_expression: nil,
+      dependent_columns: [column]
     }
   end
 
@@ -75,6 +76,14 @@ defmodule Fob.Ordering do
     query
     |> config()
     |> Enum.map(&{&1.table, &1.column})
+    |> Enum.uniq()
+  end
+
+  @spec dependent_columns(%Query{}) :: [{table(), atom(), any(), list(any())}]
+  def dependent_columns(%Query{} = query) do
+    query
+    |> config()
+    |> Enum.map(&{&1.table, &1.column, &1.dependent_columns})
     |> Enum.uniq()
   end
 

--- a/lib/fob/page_break.ex
+++ b/lib/fob/page_break.ex
@@ -16,7 +16,7 @@ defmodule Fob.PageBreak do
   """
   @type t :: %__MODULE__{}
 
-  defstruct ~w[column value table direction]a
+  defstruct ~w[column value table direction]a ++ [dependent_columns: []]
 
   @doc false
   def add_query_info(nil, _), do: nil
@@ -41,7 +41,8 @@ defmodule Fob.PageBreak do
       page_break
       | table: order.table,
         direction: order.direction,
-        value: casted_value
+        value: casted_value,
+        dependent_columns: order.dependent_columns
     }
   end
 

--- a/test/fob/fragment_builder_test.exs
+++ b/test/fob/fragment_builder_test.exs
@@ -41,4 +41,23 @@ defmodule Fob.FragmentBuilderTest do
     columns = frag |> Fob.FragmentBuilder.columns_for_fragment() |> MapSet.new()
     assert MapSet.equal?(MapSet.new([:id, :next]), columns)
   end
+
+  test "fragement builder builds captures empty columns" do
+    query =
+      from(
+        s in "schema",
+        as: :s,
+        left_join: s2 in "schema_2",
+        as: :s2,
+        select: %{
+          virtual_column: fragment("(5)")
+        },
+        order_by: [asc: fragment("(5)")]
+      )
+
+    %{expr: [{_direction, frag}]} = hd(query.order_bys)
+
+    columns = frag |> Fob.FragmentBuilder.columns_for_fragment() |> MapSet.new()
+    assert MapSet.equal?(MapSet.new(), columns)
+  end
 end


### PR DESCRIPTION
This adds some ordering column meta data to the PageBreak struct. This allows other libraries to check which columns are expected to effect the sort order as managed by Fob.
